### PR TITLE
[codex] retry Bluetooth discovery on BlueZ InProgress

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import asyncio
 import logging
 
+from bleak.exc import BleakDBusError
 from switchbot.discovery import GetSwitchbotDevices
 
 from influxdb_client import InfluxDBClient, Point
@@ -12,6 +13,38 @@ from dotenv import load_dotenv
 # --- Logging Setup ---
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+SCAN_TIMEOUT_SECONDS = 60
+DISCOVERY_RETRY_COUNT = 3
+DISCOVERY_RETRY_BASE_DELAY_SECONDS = 1.0
+
+
+async def discover_switchbot_devices(scan_timeout: int = SCAN_TIMEOUT_SECONDS) -> dict:
+    """Discover SwitchBot devices, retrying transient BlueZ busy errors."""
+    delay_seconds = DISCOVERY_RETRY_BASE_DELAY_SECONDS
+
+    for attempt in range(1, DISCOVERY_RETRY_COUNT + 1):
+        try:
+            return await GetSwitchbotDevices().discover(scan_timeout=scan_timeout)
+        except BleakDBusError as exc:
+            if "InProgress" not in str(exc):
+                raise
+
+            if attempt == DISCOVERY_RETRY_COUNT:
+                logger.exception(
+                    "Bluetooth discovery failed after %s attempts because the adapter remained busy.",
+                    attempt,
+                )
+                raise
+
+            logger.warning(
+                "Bluetooth adapter is busy during discovery (%s/%s). Retrying in %.1f seconds.",
+                attempt,
+                DISCOVERY_RETRY_COUNT,
+                delay_seconds,
+            )
+            await asyncio.sleep(delay_seconds)
+            delay_seconds *= 2
 
 # --- Main Function ---
 async def main():
@@ -36,7 +69,7 @@ async def main():
     write_api = client.write_api(write_options=SYNCHRONOUS)
     logger.info("InfluxDB client initialized.")
 
-    sensors = await GetSwitchbotDevices().discover(scan_timeout=60)
+    sensors = await discover_switchbot_devices()
     if not sensors:
         logger.warning("No temperature sensors found. Exiting.")
         return

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 SCAN_TIMEOUT_SECONDS = 60
 DISCOVERY_RETRY_COUNT = 3
 DISCOVERY_RETRY_BASE_DELAY_SECONDS = 1.0
+BLUEZ_IN_PROGRESS_ERROR = "org.bluez.Error.InProgress"
 
 
 async def discover_switchbot_devices(scan_timeout: int = SCAN_TIMEOUT_SECONDS) -> dict:
@@ -27,7 +28,7 @@ async def discover_switchbot_devices(scan_timeout: int = SCAN_TIMEOUT_SECONDS) -
         try:
             return await GetSwitchbotDevices().discover(scan_timeout=scan_timeout)
         except BleakDBusError as exc:
-            if "InProgress" not in str(exc):
+            if getattr(exc, "dbus_error", None) != BLUEZ_IN_PROGRESS_ERROR:
                 raise
 
             if attempt == DISCOVERY_RETRY_COUNT:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "influxdb-client>=1.48.0",
+    "bleak>=0.22.3",
     "pyswitchbot",
     "python-dotenv>=1.1.0",
 ]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -95,7 +95,7 @@ async def test_environment_variables_missing_measurement(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_discovery_retries_on_bleak_dbus_in_progress(monkeypatch):
+async def test_discovery_retries_on_bleak_dbus_in_progress():
     """Bluetooth discovery should retry once when BlueZ reports InProgress."""
     discovered_sensor = MagicMock()
     first_scanner = MagicMock()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -120,4 +120,4 @@ async def test_discovery_retries_on_bleak_dbus_in_progress(monkeypatch):
     assert mock_get_devices.call_count == 2
     first_scanner.discover.assert_awaited_once_with(scan_timeout=1)
     second_scanner.discover.assert_awaited_once_with(scan_timeout=1)
-    mock_sleep.assert_awaited_once_with(1.0)
+    mock_sleep.assert_awaited_once_with(main.DISCOVERY_RETRY_BASE_DELAY_SECONDS)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,6 +2,7 @@ import os
 import sys
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
+from bleak.exc import BleakDBusError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
@@ -92,3 +93,31 @@ async def test_environment_variables_missing_measurement(monkeypatch):
         await main.main()
     assert "Missing InfluxDB environment variables." in str(excinfo.value)
 
+
+@pytest.mark.asyncio
+async def test_discovery_retries_on_bleak_dbus_in_progress(monkeypatch):
+    """Bluetooth discovery should retry once when BlueZ reports InProgress."""
+    discovered_sensor = MagicMock()
+    first_scanner = MagicMock()
+    first_scanner.discover = AsyncMock(
+        side_effect=BleakDBusError(
+            "org.bluez.Error.InProgress",
+            ["Operation already in progress"],
+        )
+    )
+    second_scanner = MagicMock()
+    second_scanner.discover = AsyncMock(return_value={"test_address": discovered_sensor})
+
+    with patch(
+        "main.GetSwitchbotDevices",
+        side_effect=[first_scanner, second_scanner],
+    ) as mock_get_devices, patch("main.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        import main
+
+        result = await main.discover_switchbot_devices(scan_timeout=1)
+
+    assert result == {"test_address": discovered_sensor}
+    assert mock_get_devices.call_count == 2
+    first_scanner.discover.assert_awaited_once_with(scan_timeout=1)
+    second_scanner.discover.assert_awaited_once_with(scan_timeout=1)
+    mock_sleep.assert_awaited_once_with(1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -719,6 +719,7 @@ name = "switchbot-ble-to-influxdb"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "bleak" },
     { name = "influxdb-client" },
     { name = "pyswitchbot" },
     { name = "python-dotenv" },
@@ -734,6 +735,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "influxdb-client", specifier = ">=1.48.0" },
+    { name = "bleak", specifier = ">=0.22.3" },
     { name = "pyswitchbot" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
 ]


### PR DESCRIPTION
## What changed
- Added a small retry wrapper around SwitchBot device discovery.
- The wrapper catches `BleakDBusError` with `InProgress` and retries with exponential backoff.
- Added a unit test that simulates a transient BlueZ busy error followed by a successful retry.

## Why
- Raspberry Pi/systemd runs can occasionally hit `org.bluez.Error.InProgress` when BlueZ is already handling another Bluetooth operation.
- The previous implementation called discovery once and failed immediately on that transient state.

## Impact
- Temporary Bluetooth contention should now recover automatically instead of dropping the whole run.
- The change is scoped to discovery and does not alter InfluxDB writes or device filtering.

## Validation
- `./.venv/bin/pytest tests/unit/test_main.py`
- `./.venv/bin/pytest tests/integration/test_main_integration.py`
