### PR TITLE
[codex] keep partial Bluetooth scan results on InProgress

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,25 +20,39 @@ DISCOVERY_RETRY_BASE_DELAY_SECONDS = 1.0
 BLUEZ_IN_PROGRESS_ERROR = "org.bluez.Error.InProgress"
 
 
+def _get_partial_discovery_results(discoverer: GetSwitchbotDevices) -> dict | None:
+    """Return collected scan results if the current switchbot version exposes them.
+
+    pyswitchbot currently stores in-progress scan data on the private `_adv_data`
+    attribute, so we isolate that compatibility dependency here.
+    """
+    partial_adv_data = getattr(discoverer, "_adv_data", None)
+    if isinstance(partial_adv_data, dict) and partial_adv_data:
+        return dict(partial_adv_data)
+    return None
+
+
 async def discover_switchbot_devices(scan_timeout: int = SCAN_TIMEOUT_SECONDS) -> dict:
     """Discover SwitchBot devices, retrying transient BlueZ busy errors."""
     delay_seconds = DISCOVERY_RETRY_BASE_DELAY_SECONDS
 
     for attempt in range(1, DISCOVERY_RETRY_COUNT + 1):
-        discoverer = GetSwitchbotDevices()
+        discoverer = None
         try:
+            discoverer = GetSwitchbotDevices()
             return await discoverer.discover(scan_timeout=scan_timeout)
         except BleakDBusError as exc:
             if getattr(exc, "dbus_error", None) != BLUEZ_IN_PROGRESS_ERROR:
                 raise
 
-            partial_adv_data = getattr(discoverer, "_adv_data", None)
-            if isinstance(partial_adv_data, dict) and partial_adv_data:
+            if discoverer is not None and (
+                partial_results := _get_partial_discovery_results(discoverer)
+            ):
                 logger.warning(
                     "Bluetooth discovery stopped with InProgress, but %s devices were already collected. Using partial results.",
-                    len(partial_adv_data),
+                    len(partial_results),
                 )
-                return dict(partial_adv_data)
+                return partial_results
 
             if attempt == DISCOVERY_RETRY_COUNT:
                 logger.exception(

--- a/main.py
+++ b/main.py
@@ -25,11 +25,20 @@ async def discover_switchbot_devices(scan_timeout: int = SCAN_TIMEOUT_SECONDS) -
     delay_seconds = DISCOVERY_RETRY_BASE_DELAY_SECONDS
 
     for attempt in range(1, DISCOVERY_RETRY_COUNT + 1):
+        discoverer = GetSwitchbotDevices()
         try:
-            return await GetSwitchbotDevices().discover(scan_timeout=scan_timeout)
+            return await discoverer.discover(scan_timeout=scan_timeout)
         except BleakDBusError as exc:
             if getattr(exc, "dbus_error", None) != BLUEZ_IN_PROGRESS_ERROR:
                 raise
+
+            partial_adv_data = getattr(discoverer, "_adv_data", None)
+            if isinstance(partial_adv_data, dict) and partial_adv_data:
+                logger.warning(
+                    "Bluetooth discovery stopped with InProgress, but %s devices were already collected. Using partial results.",
+                    len(partial_adv_data),
+                )
+                return dict(partial_adv_data)
 
             if attempt == DISCOVERY_RETRY_COUNT:
                 logger.exception(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -124,6 +124,30 @@ async def test_discovery_retries_on_bleak_dbus_in_progress():
 
 
 @pytest.mark.asyncio
+async def test_discovery_retries_when_constructor_raises_in_progress():
+    """Bluetooth discovery should retry when scanner construction itself is busy."""
+    discovered_sensor = MagicMock()
+    second_scanner = MagicMock()
+    second_scanner.discover = AsyncMock(return_value={"test_address": discovered_sensor})
+
+    with patch(
+        "main.GetSwitchbotDevices",
+        side_effect=[
+            BleakDBusError("org.bluez.Error.InProgress", ["Operation already in progress"]),
+            second_scanner,
+        ],
+    ) as mock_get_devices, patch("main.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        import main
+
+        result = await main.discover_switchbot_devices(scan_timeout=1)
+
+    assert result == {"test_address": discovered_sensor}
+    assert mock_get_devices.call_count == 2
+    second_scanner.discover.assert_awaited_once_with(scan_timeout=1)
+    mock_sleep.assert_awaited_once_with(main.DISCOVERY_RETRY_BASE_DELAY_SECONDS)
+
+
+@pytest.mark.asyncio
 async def test_discovery_returns_partial_results_on_in_progress():
     """Bluetooth discovery should keep collected devices when stop() fails with InProgress."""
     discovered_sensor = MagicMock()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -121,3 +121,28 @@ async def test_discovery_retries_on_bleak_dbus_in_progress():
     first_scanner.discover.assert_awaited_once_with(scan_timeout=1)
     second_scanner.discover.assert_awaited_once_with(scan_timeout=1)
     mock_sleep.assert_awaited_once_with(main.DISCOVERY_RETRY_BASE_DELAY_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_discovery_returns_partial_results_on_in_progress():
+    """Bluetooth discovery should keep collected devices when stop() fails with InProgress."""
+    discovered_sensor = MagicMock()
+    discoverer = MagicMock()
+    discoverer._adv_data = {"test_address": discovered_sensor}
+    discoverer.discover = AsyncMock(
+        side_effect=BleakDBusError(
+            "org.bluez.Error.InProgress",
+            ["Operation already in progress"],
+        )
+    )
+
+    with patch("main.GetSwitchbotDevices", return_value=discoverer) as mock_get_devices, \
+        patch("main.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        import main
+
+        result = await main.discover_switchbot_devices(scan_timeout=1)
+
+    assert result == {"test_address": discovered_sensor}
+    mock_get_devices.assert_called_once()
+    discoverer.discover.assert_awaited_once_with(scan_timeout=1)
+    mock_sleep.assert_not_called()


### PR DESCRIPTION
## What changed
- When Bluetooth discovery ends with `org.bluez.Error.InProgress` during scanner shutdown, the code now uses any partial `_adv_data` already collected instead of discarding it.
- Kept the existing retry path when no partial data exists.
- Added a unit test covering the partial-results case.

## Why
- On Raspberry Pi, the failure was happening in `devices.stop()` after the scan window had already elapsed.
- In that case, BlueZ can report `InProgress` even though useful advertisement data has already been gathered.
- Retrying alone was not enough because the same shutdown error could repeat.

## Validation
- `./.venv/bin/pytest tests/unit/test_main.py`
- `./.venv/bin/pytest tests/integration/test_main_integration.py`
