### PR TITLE
[codex] scan SwitchBot devices directly with stop retries

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
 import os
 import asyncio
 import logging
+from collections.abc import Callable
 
+from bleak import BleakScanner
 from bleak.exc import BleakDBusError
-from switchbot.discovery import GetSwitchbotDevices
+from switchbot.adv_parser import parse_advertisement_data
+from switchbot.discovery import CONNECT_LOCK
 
 from influxdb_client import InfluxDBClient, Point
 from influxdb_client.client.write_api import SYNCHRONOUS
@@ -18,18 +21,71 @@ SCAN_TIMEOUT_SECONDS = 60
 DISCOVERY_RETRY_COUNT = 3
 DISCOVERY_RETRY_BASE_DELAY_SECONDS = 1.0
 BLUEZ_IN_PROGRESS_ERROR = "org.bluez.Error.InProgress"
+BLUEZ_ADAPTER = "hci0"
 
 
-def _get_partial_discovery_results(discoverer: GetSwitchbotDevices) -> dict | None:
-    """Return collected scan results if the current switchbot version exposes them.
+def _build_detection_callback(discovered_devices: dict) -> Callable[[object, object], None]:
+    """Build a callback that accumulates SwitchBot advertisements."""
+    def detection_callback(device, advertisement_data) -> None:
+        discovery = parse_advertisement_data(device, advertisement_data)
+        if discovery:
+            discovered_devices[discovery.address] = discovery
 
-    pyswitchbot currently stores in-progress scan data on the private `_adv_data`
-    attribute, so we isolate that compatibility dependency here.
-    """
-    partial_adv_data = getattr(discoverer, "_adv_data", None)
-    if isinstance(partial_adv_data, dict) and partial_adv_data:
-        return dict(partial_adv_data)
-    return None
+    return detection_callback
+
+
+async def _stop_scanner_with_retry(scanner: BleakScanner) -> None:
+    """Stop the scanner, retrying if BlueZ reports the adapter is busy."""
+    delay_seconds = DISCOVERY_RETRY_BASE_DELAY_SECONDS
+
+    for attempt in range(1, DISCOVERY_RETRY_COUNT + 1):
+        try:
+            await scanner.stop()
+            return
+        except BleakDBusError as exc:
+            if getattr(exc, "dbus_error", None) != BLUEZ_IN_PROGRESS_ERROR:
+                raise
+
+            if attempt == DISCOVERY_RETRY_COUNT:
+                raise
+
+            logger.warning(
+                "Bluetooth adapter is busy while stopping discovery (%s/%s). Retrying in %.1f seconds.",
+                attempt,
+                DISCOVERY_RETRY_COUNT,
+                delay_seconds,
+            )
+            await asyncio.sleep(delay_seconds)
+            delay_seconds *= 2
+
+
+async def _scan_switchbot_devices_once(scan_timeout: int) -> dict:
+    """Run one Bluetooth scan and return the collected advertisements."""
+    discovered_devices: dict = {}
+    scanner = BleakScanner(
+        detection_callback=_build_detection_callback(discovered_devices),
+        adapter=BLUEZ_ADAPTER,
+    )
+
+    async with CONNECT_LOCK:
+        await scanner.start()
+        await asyncio.sleep(scan_timeout)
+        try:
+            await _stop_scanner_with_retry(scanner)
+        except BleakDBusError as exc:
+            if getattr(exc, "dbus_error", None) != BLUEZ_IN_PROGRESS_ERROR:
+                raise
+
+            if discovered_devices:
+                logger.warning(
+                    "Bluetooth discovery stopped with InProgress, but %s devices were already collected. Using partial results.",
+                    len(discovered_devices),
+                )
+                return discovered_devices
+
+            raise
+
+    return discovered_devices
 
 
 async def discover_switchbot_devices(scan_timeout: int = SCAN_TIMEOUT_SECONDS) -> dict:
@@ -37,22 +93,11 @@ async def discover_switchbot_devices(scan_timeout: int = SCAN_TIMEOUT_SECONDS) -
     delay_seconds = DISCOVERY_RETRY_BASE_DELAY_SECONDS
 
     for attempt in range(1, DISCOVERY_RETRY_COUNT + 1):
-        discoverer = None
         try:
-            discoverer = GetSwitchbotDevices()
-            return await discoverer.discover(scan_timeout=scan_timeout)
+            return await _scan_switchbot_devices_once(scan_timeout)
         except BleakDBusError as exc:
             if getattr(exc, "dbus_error", None) != BLUEZ_IN_PROGRESS_ERROR:
                 raise
-
-            if discoverer is not None and (
-                partial_results := _get_partial_discovery_results(discoverer)
-            ):
-                logger.warning(
-                    "Bluetooth discovery stopped with InProgress, but %s devices were already collected. Using partial results.",
-                    len(partial_results),
-                )
-                return partial_results
 
             if attempt == DISCOVERY_RETRY_COUNT:
                 logger.exception(

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ SCAN_TIMEOUT_SECONDS = 60
 DISCOVERY_RETRY_COUNT = 3
 DISCOVERY_RETRY_BASE_DELAY_SECONDS = 1.0
 BLUEZ_IN_PROGRESS_ERROR = "org.bluez.Error.InProgress"
-BLUEZ_ADAPTER = "hci0"
+BLEAK_ADAPTER_ENV = "BLEAK_ADAPTER"
 
 
 def _build_detection_callback(discovered_devices: dict) -> Callable[[object, object], None]:
@@ -59,31 +59,41 @@ async def _stop_scanner_with_retry(scanner: BleakScanner) -> None:
             delay_seconds *= 2
 
 
+def _create_scanner(discovered_devices: dict) -> BleakScanner:
+    """Create a scanner, optionally using the configured adapter."""
+    scanner_kwargs: dict = {
+        "detection_callback": _build_detection_callback(discovered_devices),
+    }
+    if adapter := os.getenv(BLEAK_ADAPTER_ENV):
+        scanner_kwargs["adapter"] = adapter
+
+    return BleakScanner(**scanner_kwargs)
+
+
 async def _scan_switchbot_devices_once(scan_timeout: int) -> dict:
     """Run one Bluetooth scan and return the collected advertisements."""
     discovered_devices: dict = {}
-    scanner = BleakScanner(
-        detection_callback=_build_detection_callback(discovered_devices),
-        adapter=BLUEZ_ADAPTER,
-    )
+    scanner = _create_scanner(discovered_devices)
 
     async with CONNECT_LOCK:
         await scanner.start()
-        await asyncio.sleep(scan_timeout)
         try:
-            await _stop_scanner_with_retry(scanner)
-        except BleakDBusError as exc:
-            if getattr(exc, "dbus_error", None) != BLUEZ_IN_PROGRESS_ERROR:
+            await asyncio.sleep(scan_timeout)
+        finally:
+            try:
+                await asyncio.shield(_stop_scanner_with_retry(scanner))
+            except BleakDBusError as exc:
+                if getattr(exc, "dbus_error", None) != BLUEZ_IN_PROGRESS_ERROR:
+                    raise
+
+                if discovered_devices:
+                    logger.warning(
+                        "Bluetooth discovery stopped with InProgress, but %s devices were already collected. Using partial results.",
+                        len(discovered_devices),
+                    )
+                    return discovered_devices
+
                 raise
-
-            if discovered_devices:
-                logger.warning(
-                    "Bluetooth discovery stopped with InProgress, but %s devices were already collected. Using partial results.",
-                    len(discovered_devices),
-                )
-                return discovered_devices
-
-            raise
 
     return discovered_devices
 

--- a/tests/integration/test_main_integration.py
+++ b/tests/integration/test_main_integration.py
@@ -42,16 +42,12 @@ async def test_successful_data_fetch_and_write(monkeypatch): # Added monkeypatch
         )
     }
 
-    # Mock GetSwitchbotDevices and its discover method
-    mock_get_switchbot_devices = AsyncMock()
-    mock_get_switchbot_devices.discover.return_value = mock_sensor_data
-
     # Mock InfluxDBClient and its methods
     mock_influx_client_instance = MagicMock()
     mock_write_api = MagicMock()
     mock_influx_client_instance.write_api.return_value = mock_write_api
 
-    with patch('main.GetSwitchbotDevices', return_value=mock_get_switchbot_devices) as mock_switchbot, \
+    with patch('main._scan_switchbot_devices_once', new=AsyncMock(return_value=mock_sensor_data)) as mock_scan_once, \
         patch('main.InfluxDBClient', return_value=mock_influx_client_instance), \
         patch('main.logger') as mock_logger:  # Optional: mock logger to check logs
 
@@ -59,8 +55,7 @@ async def test_successful_data_fetch_and_write(monkeypatch): # Added monkeypatch
         await reader_main_module.main()  # Changed: Call main function from the module
 
         # Assertions
-        mock_switchbot.assert_called_once()
-        mock_get_switchbot_devices.discover.assert_awaited_once()
+        mock_scan_once.assert_awaited_once()
 
         # Check if write_api.write was called with the correct data
         # This requires inspecting the 'record' argument of the call
@@ -86,23 +81,18 @@ async def test_switchbot_device_not_found(monkeypatch): # Added monkeypatch here
     """
     Tests the scenario where the specified SwitchBot device is not found.
     """
-    # Mock GetSwitchbotDevices to return no sensors or an empty dict
-    mock_get_switchbot_devices = AsyncMock()
-    mock_get_switchbot_devices.discover.return_value = {} # No sensors found
-
     mock_influx_client_instance = MagicMock()
     mock_write_api = MagicMock()
     mock_influx_client_instance.write_api.return_value = mock_write_api
 
-    with patch('main.GetSwitchbotDevices', return_value=mock_get_switchbot_devices) as mock_switchbot, \
+    with patch('main._scan_switchbot_devices_once', new=AsyncMock(return_value={} )) as mock_scan_once, \
         patch('main.InfluxDBClient', return_value=mock_influx_client_instance), \
         patch('main.logger') as mock_logger:
 
         import main as reader_main_module
         await reader_main_module.main()  # Changed: Call main function from the module
 
-        mock_switchbot.assert_called_once()
-        mock_get_switchbot_devices.discover.assert_awaited_once()
+        mock_scan_once.assert_awaited_once()
         # Client is still initialized
 
         # Ensure write was not called as no device data should be processed
@@ -132,24 +122,20 @@ async def test_influxdb_write_failure(monkeypatch): # Added monkeypatch here
         )
     }
 
-    mock_get_switchbot_devices = AsyncMock()
-    mock_get_switchbot_devices.discover.return_value = mock_sensor_data
-
     mock_influx_client_instance = MagicMock()
     mock_write_api = MagicMock()
     # Simulate an exception during write
     mock_write_api.write.side_effect = Exception("InfluxDB write error")
     mock_influx_client_instance.write_api.return_value = mock_write_api
 
-    with patch('main.GetSwitchbotDevices', return_value=mock_get_switchbot_devices) as mock_switchbot, \
+    with patch('main._scan_switchbot_devices_once', new=AsyncMock(return_value=mock_sensor_data)) as mock_scan_once, \
         patch('main.InfluxDBClient', return_value=mock_influx_client_instance), \
         patch('main.logger') as mock_logger:
 
         import main as reader_main_module
         await reader_main_module.main()  # Changed: Call main function from the module
 
-        mock_switchbot.assert_called_once()
-        mock_get_switchbot_devices.discover.assert_awaited_once()
+        mock_scan_once.assert_awaited_once()
         mock_write_api.write.assert_called_once() # Write was attempted
 
         # Check for the error log
@@ -171,22 +157,18 @@ async def test_specific_device_id_not_in_scan_results(monkeypatch): # Added monk
         )
     }
 
-    mock_get_switchbot_devices = AsyncMock()
-    mock_get_switchbot_devices.discover.return_value = mock_sensor_data
-
     mock_influx_client_instance = MagicMock()
     mock_write_api = MagicMock()
     mock_influx_client_instance.write_api.return_value = mock_write_api
 
-    with patch('main.GetSwitchbotDevices', return_value=mock_get_switchbot_devices) as mock_get_devices, \
+    with patch('main._scan_switchbot_devices_once', new=AsyncMock(return_value=mock_sensor_data)) as mock_scan_once, \
         patch('main.InfluxDBClient', return_value=mock_influx_client_instance), \
         patch('main.logger') as mock_logger:
 
         import main as reader_main_module
         await reader_main_module.main()  # Changed: Call main function from the module
 
-        mock_get_devices.assert_called_once() # Ensure GetSwitchbotDevices was called
-        mock_get_switchbot_devices.discover.assert_awaited_once()
+        mock_scan_once.assert_awaited_once()
         mock_write_api.write.assert_not_called() # No data should be written
         mock_logger.info.assert_any_call("Skipping device XX:XX:XX:XX:XX:XX as it does not match DEVICE_ID YY:YY:YY:YY:YY:YY")
 
@@ -211,21 +193,18 @@ async def test_device_id_filter_selects_correct_device(monkeypatch): # Added mon
         ),
     }
 
-    mock_get_switchbot_devices = AsyncMock()
-    mock_get_switchbot_devices.discover.return_value = mock_sensor_data
-
     mock_influx_client_instance = MagicMock()
     mock_write_api = MagicMock()
     mock_influx_client_instance.write_api.return_value = mock_write_api
 
-    with patch('main.GetSwitchbotDevices', return_value=mock_get_switchbot_devices) as mock_get_devices, \
+    with patch('main._scan_switchbot_devices_once', new=AsyncMock(return_value=mock_sensor_data)) as mock_scan_once, \
         patch('main.InfluxDBClient', return_value=mock_influx_client_instance), \
         patch('main.logger') as mock_logger:
 
         import main as reader_main_module
         await reader_main_module.main()  # Changed: Call main function from the module
 
-        mock_get_devices.assert_called_once() # Ensure GetSwitchbotDevices was called
+        mock_scan_once.assert_awaited_once()
         mock_write_api.write.assert_called_once() # Should be called exactly once for the target device
         args, kwargs = mock_write_api.write.call_args
         point = kwargs['record']
@@ -235,4 +214,3 @@ async def test_device_id_filter_selects_correct_device(monkeypatch): # Added mon
         mock_logger.info.assert_any_call("Skipping device XX:XX:XX:XX:XX:XX as it does not match DEVICE_ID TARGET_DEVICE_ADDR")
         mock_logger.info.assert_any_call("Skipping device ZZ:ZZ:ZZ:ZZ:ZZ:ZZ as it does not match DEVICE_ID TARGET_DEVICE_ADDR")
         mock_logger.info.assert_any_call("Data written to InfluxDB for device TARGET_DEVICE_ADDR")
-

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import asyncio
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from bleak.exc import BleakDBusError
@@ -149,3 +150,44 @@ async def test_discovery_returns_partial_results_when_stop_is_busy():
     assert mock_sleep.await_count == 3
     # stop() is retried three times inside the single scan attempt
     # and no outer retry is needed because partial data is returned.
+
+
+@pytest.mark.asyncio
+async def test_create_scanner_uses_configured_adapter(monkeypatch):
+    """Scanner creation should respect an explicit adapter override."""
+    monkeypatch.setenv("BLEAK_ADAPTER", "hci1")
+    discovered_devices = {}
+
+    with patch("main.BleakScanner") as mock_scanner:
+        import main
+
+        main._create_scanner(discovered_devices)
+
+    mock_scanner.assert_called_once()
+    _, kwargs = mock_scanner.call_args
+    assert kwargs["adapter"] == "hci1"
+
+
+@pytest.mark.asyncio
+async def test_scan_attempt_cleans_up_scanner_when_sleep_is_cancelled():
+    """The scanner should still be stopped if the scan coroutine is cancelled."""
+    stop_called = AsyncMock()
+
+    class FakeScanner:
+        def __init__(self, detection_callback):
+            self.detection_callback = detection_callback
+            self.start = AsyncMock(return_value=None)
+            self.stop = stop_called
+
+    with patch(
+        "main.BleakScanner",
+        side_effect=lambda **kwargs: FakeScanner(kwargs["detection_callback"]),
+    ), patch("main.parse_advertisement_data", return_value=None), patch(
+        "main.asyncio.sleep", new=AsyncMock(side_effect=asyncio.CancelledError())
+    ):
+        import main
+
+        with pytest.raises(asyncio.CancelledError):
+            await main._scan_switchbot_devices_once(scan_timeout=1)
+
+    assert stop_called.await_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -36,9 +36,8 @@ def mock_switchbot_devices():
 @pytest.mark.asyncio
 async def test_environment_variables_present(mock_env_vars, mock_switchbot_devices, caplog):
     """環境変数がすべて設定されている場合のテスト"""
-    with patch('main.GetSwitchbotDevices') as MockGetSwitchbotDevices, \
+    with patch('main._scan_switchbot_devices_once', new=AsyncMock(return_value=mock_switchbot_devices)), \
          patch('main.InfluxDBClient'):
-        MockGetSwitchbotDevices.return_value.discover = AsyncMock(return_value=mock_switchbot_devices)
         import main
         # 環境変数が正しく設定されていることをデバッグ
         print("Environment Variables:")
@@ -96,77 +95,57 @@ async def test_environment_variables_missing_measurement(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_discovery_retries_on_bleak_dbus_in_progress():
-    """Bluetooth discovery should retry once when BlueZ reports InProgress."""
+    """Bluetooth discovery should retry the whole scan when the attempt is busy."""
     discovered_sensor = MagicMock()
-    first_scanner = MagicMock()
-    first_scanner.discover = AsyncMock(
-        side_effect=BleakDBusError(
-            "org.bluez.Error.InProgress",
-            ["Operation already in progress"],
-        )
-    )
-    second_scanner = MagicMock()
-    second_scanner.discover = AsyncMock(return_value={"test_address": discovered_sensor})
 
     with patch(
-        "main.GetSwitchbotDevices",
-        side_effect=[first_scanner, second_scanner],
-    ) as mock_get_devices, patch("main.asyncio.sleep", new=AsyncMock()) as mock_sleep:
-        import main
-
-        result = await main.discover_switchbot_devices(scan_timeout=1)
-
-    assert result == {"test_address": discovered_sensor}
-    assert mock_get_devices.call_count == 2
-    first_scanner.discover.assert_awaited_once_with(scan_timeout=1)
-    second_scanner.discover.assert_awaited_once_with(scan_timeout=1)
-    mock_sleep.assert_awaited_once_with(main.DISCOVERY_RETRY_BASE_DELAY_SECONDS)
-
-
-@pytest.mark.asyncio
-async def test_discovery_retries_when_constructor_raises_in_progress():
-    """Bluetooth discovery should retry when scanner construction itself is busy."""
-    discovered_sensor = MagicMock()
-    second_scanner = MagicMock()
-    second_scanner.discover = AsyncMock(return_value={"test_address": discovered_sensor})
-
-    with patch(
-        "main.GetSwitchbotDevices",
+        "main._scan_switchbot_devices_once",
         side_effect=[
             BleakDBusError("org.bluez.Error.InProgress", ["Operation already in progress"]),
-            second_scanner,
+            {"test_address": discovered_sensor},
         ],
-    ) as mock_get_devices, patch("main.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+    ) as mock_scan_once, patch("main.asyncio.sleep", new=AsyncMock()) as mock_sleep:
         import main
 
         result = await main.discover_switchbot_devices(scan_timeout=1)
 
     assert result == {"test_address": discovered_sensor}
-    assert mock_get_devices.call_count == 2
-    second_scanner.discover.assert_awaited_once_with(scan_timeout=1)
+    assert mock_scan_once.call_count == 2
     mock_sleep.assert_awaited_once_with(main.DISCOVERY_RETRY_BASE_DELAY_SECONDS)
 
 
 @pytest.mark.asyncio
-async def test_discovery_returns_partial_results_on_in_progress():
-    """Bluetooth discovery should keep collected devices when stop() fails with InProgress."""
+async def test_discovery_returns_partial_results_when_stop_is_busy():
+    """Bluetooth discovery should return collected devices if stop() keeps failing."""
     discovered_sensor = MagicMock()
-    discoverer = MagicMock()
-    discoverer._adv_data = {"test_address": discovered_sensor}
-    discoverer.discover = AsyncMock(
-        side_effect=BleakDBusError(
-            "org.bluez.Error.InProgress",
-            ["Operation already in progress"],
-        )
-    )
+    discovered_sensor.address = "test_address"
 
-    with patch("main.GetSwitchbotDevices", return_value=discoverer) as mock_get_devices, \
+    class FakeScanner:
+        def __init__(self, detection_callback):
+            self.detection_callback = detection_callback
+            self.start = AsyncMock(side_effect=self._start)
+            self.stop = AsyncMock(
+                side_effect=[
+                    BleakDBusError("org.bluez.Error.InProgress", ["Operation already in progress"]),
+                    BleakDBusError("org.bluez.Error.InProgress", ["Operation already in progress"]),
+                    BleakDBusError("org.bluez.Error.InProgress", ["Operation already in progress"]),
+                ]
+            )
+
+        async def _start(self):
+            device = MagicMock()
+            device.address = "test_address"
+            self.detection_callback(device, MagicMock())
+
+    with patch("main.BleakScanner", side_effect=lambda **kwargs: FakeScanner(kwargs["detection_callback"])), \
+        patch("main.parse_advertisement_data", return_value=discovered_sensor), \
         patch("main.asyncio.sleep", new=AsyncMock()) as mock_sleep:
         import main
 
-        result = await main.discover_switchbot_devices(scan_timeout=1)
+        result = await main._scan_switchbot_devices_once(scan_timeout=1)
 
     assert result == {"test_address": discovered_sensor}
-    mock_get_devices.assert_called_once()
-    discoverer.discover.assert_awaited_once_with(scan_timeout=1)
-    mock_sleep.assert_not_called()
+    mock_sleep.assert_any_await(1)
+    assert mock_sleep.await_count == 3
+    # stop() is retried three times inside the single scan attempt
+    # and no outer retry is needed because partial data is returned.


### PR DESCRIPTION
## What changed
- Replaced the `pyswitchbot` discovery wrapper with a direct `BleakScanner` scan path.
- Retries `scanner.stop()` when BlueZ reports `org.bluez.Error.InProgress`.
- Returns partial results if devices were already collected before the stop failure.
- Updated tests to cover the new scan flow.

## Why
- The failure in production was happening at `stop()`, after the scan window had already collected data.
- Retrying the whole discovery call was not enough because the same stop error repeated.
- Using the scanner directly lets us retry the failing stop operation in place and preserve collected results.

## Validation
- `./.venv/bin/pytest tests/unit/test_main.py`
- `./.venv/bin/pytest tests/integration/test_main_integration.py`
